### PR TITLE
feat: adiciona estrutura base para previsao de churn

### DIFF
--- a/src/main/java/equipe25/churninsight_backend/integration/ChurnModelClient.java
+++ b/src/main/java/equipe25/churninsight_backend/integration/ChurnModelClient.java
@@ -1,0 +1,11 @@
+package equipe25.churninsight_backend.integration;
+
+import java.util.Map;
+
+import equipe25.churninsight_backend.integration.model.PredictionResult;
+
+public interface ChurnModelClient {
+
+    PredictionResult predictionResult(Map<String, Object> payload);
+
+}

--- a/src/main/java/equipe25/churninsight_backend/integration/ChurnModelClientMock.java
+++ b/src/main/java/equipe25/churninsight_backend/integration/ChurnModelClientMock.java
@@ -1,0 +1,51 @@
+package equipe25.churninsight_backend.integration;
+
+import java.util.Map;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import equipe25.churninsight_backend.integration.model.PredictionResult;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Profile("mock")
+@Slf4j
+public class ChurnModelClientMock implements ChurnModelClient {
+
+    @Override
+    public PredictionResult predictionResult(Map<String, Object> payload) {
+
+        log.info("Usando MOCK de Data Science");
+
+        Integer creditScore = (Integer) payload.get("CreditScore");
+        Integer age = (Integer) payload.get("Age");
+        Double balance = payload.get("Balance") != null
+                ? ((Number) payload.get("Balance")).doubleValue()
+                : 0.0;
+
+        double probabilidade;
+        String previsao;
+
+        // Regraa mockada simples
+        if (creditScore != null && creditScore < 500) {
+            probabilidade = 0.82;
+            previsao = "Vai cancelar";
+        } else if (balance < 1000) {
+            probabilidade = 0.67;
+            previsao = "Vai cancelar";
+        } else if (age != null && age > 55) {
+            probabilidade = 0.45;
+            previsao = "Vai continuar";
+        } else {
+            probabilidade = 0.24;
+            previsao = "Vai continuar";
+        }
+
+        return PredictionResult.builder()
+                .previsao(previsao)
+                .probabilidade(probabilidade) // nivelRisco e recomendacao trataremos na Serivce
+                .build();
+    }
+
+}

--- a/src/main/java/equipe25/churninsight_backend/integration/model/PredictionResult.java
+++ b/src/main/java/equipe25/churninsight_backend/integration/model/PredictionResult.java
@@ -1,0 +1,27 @@
+package equipe25.churninsight_backend.integration.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PredictionResult {
+
+    /*
+     * Quando enum existir, substituir:
+     * private ChurnPrediction previsao;
+     */
+    private String previsao;
+    private Double probabilidade;
+    /*
+     * Quando enum existir, substituir:
+     * private RiskLevel nivelRisco;
+     */
+    private String nivelRisco;
+    private String recomendacao;
+
+}

--- a/src/main/resources/application-mock.properties
+++ b/src/main/resources/application-mock.properties
@@ -1,0 +1,2 @@
+# configs específicas do profile mock
+# (vazio por enquanto)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=churninsight-backend
+spring.profiles.active=mock


### PR DESCRIPTION
Estrutura criada para viabilizar a implementacao do Service e Controller de previsao, incluindo contrato de integracao e mock de Data Science. Nao contempla logica de negocio nem endpoints finais.