### PR TITLE
test: adicionar suite completa de testes unitários de prever() da Pre…

### DIFF
--- a/src/test/java/equipe25/churninsight_backend/service/PrevisaoServicePreverTestes.java
+++ b/src/test/java/equipe25/churninsight_backend/service/PrevisaoServicePreverTestes.java
@@ -1,0 +1,139 @@
+package equipe25.churninsight_backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import equipe25.churninsight_backend.application.api.dto.ClienteRequest;
+import equipe25.churninsight_backend.application.api.dto.ClienteResponse;
+import equipe25.churninsight_backend.application.api.service.PrevisaoClienteService;
+import equipe25.churninsight_backend.application.nivelrisco.NivelRiscoRepository;
+import equipe25.churninsight_backend.application.previsao.repository.PrevisaoRepository;
+import equipe25.churninsight_backend.application.previsao.service.PrevisaoService;
+import equipe25.churninsight_backend.application.tipoprevisao.TipoPrevisaoRepository;
+import equipe25.churninsight_backend.model.nivelrisco.NivelRiscoEntidade;
+import equipe25.churninsight_backend.model.previsao.Previsao;
+import equipe25.churninsight_backend.model.tipoprevisao.TipoPrevisaoEntidade;
+import equipe25.churninsight_backend.utils.FabricaObjetosTeste;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+public class PrevisaoServicePreverTestes {
+
+    @Mock
+    private PrevisaoRepository previsaoRepository;
+
+    @Mock
+    private PrevisaoClienteService previsaoClienteService;
+
+    @Mock
+    private NivelRiscoRepository nivelRiscoRepository;
+
+    @Mock
+    private TipoPrevisaoRepository tipoPrevisaoRepository;
+
+    @InjectMocks
+    private PrevisaoService previsaoService;
+
+    private TipoPrevisaoEntidade tipoPrevisaoEntidade;
+    private NivelRiscoEntidade nivelRiscoEntidade;
+    private ClienteRequest request;
+    private ClienteResponse response;
+
+    @BeforeEach
+    void setup() {
+        tipoPrevisaoEntidade = FabricaObjetosTeste.criarPrevisaoVaiContinuar();
+        nivelRiscoEntidade = FabricaObjetosTeste.criarNivelBaixo();
+
+        request = FabricaObjetosTeste.criarRequest();
+        response = FabricaObjetosTeste.criarResponse();
+    }
+
+    @Nested
+    class PositiveCases {
+        @Test
+        void deveriaRetornarCorretamente() {
+            when(previsaoClienteService.prever(any()))
+                    .thenReturn(response);
+
+            when(tipoPrevisaoRepository.findById(tipoPrevisaoEntidade.getId()))
+                    .thenReturn(Optional.of(tipoPrevisaoEntidade));
+
+            when(nivelRiscoRepository.findById(nivelRiscoEntidade.getId()))
+                    .thenReturn(Optional.of(nivelRiscoEntidade));
+
+            ArgumentCaptor<Previsao> captor = ArgumentCaptor.forClass(Previsao.class);
+
+            ClienteResponse result = previsaoService.prever(request);
+
+            assertNotNull(result);
+            assertEquals(response, result);
+
+            verify(previsaoRepository).save(captor.capture());
+
+            Previsao previsaoSalva = captor.getValue();
+            assertEquals(tipoPrevisaoEntidade, previsaoSalva.getPrevisao());
+            assertEquals(nivelRiscoEntidade, previsaoSalva.getNivelRisco());
+            assertEquals(response.probabilidade(), previsaoSalva.getProbabilidade());
+            assertEquals(response.recomendacao(), previsaoSalva.getRecomendacao());
+        }
+    }
+
+    @Nested
+    class NegativeCases {
+        @Test
+        void deveFalharQuandoTipoPrevisaoNaoEncontrado() {
+            when(previsaoClienteService.prever(any()))
+                    .thenReturn(response);
+
+            when(tipoPrevisaoRepository.findById(tipoPrevisaoEntidade.getId()))
+                    .thenReturn(Optional.empty());
+
+            IllegalStateException exception = assertThrows(
+                    IllegalStateException.class,
+                    () -> previsaoService.prever(request));
+
+            assertTrue(exception.getMessage().contains("Tipo Previsão não encontrado"));
+
+            verify(previsaoRepository, never()).save(any(Previsao.class));
+        }
+
+        @Test
+        void deveFalharQuandoNivelRiscoNaoEncontrado() {
+            when(previsaoClienteService.prever(any()))
+                    .thenReturn(response);
+
+            when(tipoPrevisaoRepository.findById(tipoPrevisaoEntidade.getId()))
+                    .thenReturn(Optional.of(tipoPrevisaoEntidade));
+
+            when(nivelRiscoRepository.findById(nivelRiscoEntidade.getId()))
+                    .thenReturn(Optional.empty());
+
+            IllegalStateException exception = assertThrows(
+                    IllegalStateException.class,
+                    () -> previsaoService.prever(request));
+
+            assertTrue(exception.getMessage().contains("Nível Risco não encontrado"));
+
+            verify(previsaoRepository, never()).save(any(Previsao.class));
+        }
+    }
+
+}

--- a/src/test/java/equipe25/churninsight_backend/utils/FabricaObjetosTeste.java
+++ b/src/test/java/equipe25/churninsight_backend/utils/FabricaObjetosTeste.java
@@ -1,0 +1,85 @@
+package equipe25.churninsight_backend.utils;
+
+import equipe25.churninsight_backend.application.api.dto.ClienteRequest;
+import equipe25.churninsight_backend.application.api.dto.ClienteResponse;
+import equipe25.churninsight_backend.model.genero.GeneroEntidade;
+import equipe25.churninsight_backend.model.genero.enums.GeneroEnum;
+import equipe25.churninsight_backend.model.nivelrisco.NivelRiscoEntidade;
+import equipe25.churninsight_backend.model.nivelrisco.enums.NivelRiscoEnum;
+import equipe25.churninsight_backend.model.pais.PaisEntidade;
+import equipe25.churninsight_backend.model.pais.enums.PaisEnum;
+import equipe25.churninsight_backend.model.previsao.Previsao;
+import equipe25.churninsight_backend.model.tipoprevisao.TipoPrevisaoEntidade;
+import equipe25.churninsight_backend.model.tipoprevisao.enums.TipoPrevisaoEnum;
+
+public class FabricaObjetosTeste {
+
+    public static GeneroEntidade criarGeneroMale() {
+        return GeneroEntidade.fromEnum(GeneroEnum.MALE);
+    }
+
+    public static GeneroEnum generoMaleEnum() {
+        return GeneroEnum.MALE;
+    }
+
+    public static NivelRiscoEntidade criarNivelBaixo() {
+        return NivelRiscoEntidade.fromEnum(NivelRiscoEnum.BAIXO);
+    }
+
+    public static NivelRiscoEnum nivelRiscoEnumBaixo() {
+        return NivelRiscoEnum.BAIXO;
+    }
+
+    public static PaisEntidade criarPaisFrance() {
+        return PaisEntidade.fromEnum(PaisEnum.FRANCE);
+    }
+
+    public static PaisEnum paisEnumFrance() {
+        return PaisEnum.FRANCE;
+    }
+
+    public static TipoPrevisaoEntidade criarPrevisaoVaiContinuar() {
+        return TipoPrevisaoEntidade.fromEnum(TipoPrevisaoEnum.VAI_CONTINUAR);
+    }
+
+    public static TipoPrevisaoEnum previsaoEnumVaiContinuar() {
+        return TipoPrevisaoEnum.VAI_CONTINUAR;
+    }
+
+    public static Previsao criarPrevisao() {
+        Previsao previsao = new Previsao();
+        previsao.setId(1L);
+        previsao.setPrevisao(criarPrevisaoVaiContinuar());
+        previsao.setNivelRisco(criarNivelBaixo());
+        previsao.setProbabilidade(7.12);
+        previsao.setRecomendacao("Recomendação.");
+
+        return previsao;
+    }
+
+    public static ClienteResponse criarResponse() {
+        Previsao previsao = criarPrevisao();
+
+        ClienteResponse response = new ClienteResponse(
+                TipoPrevisaoEnum.fromJson(previsao.getPrevisao().getTipoPrevisao()),
+                previsao.getProbabilidade(),
+                NivelRiscoEnum.fromJson(previsao.getNivelRisco().getNivelRiscoNome()),
+                previsao.getRecomendacao());
+
+        return response;
+    }
+
+    public static ClienteRequest criarRequest() {
+        ClienteRequest request = new ClienteRequest(
+                12,
+                paisEnumFrance(),
+                generoMaleEnum(),
+                29,
+                21,
+                7.07,
+                2000.0);
+
+        return request;
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,22 @@
+spring.application.name=churninsight-backend - Test Profile
+
+# ===============================
+# DATASOURCE - H2 EM MEMÖRIA
+# ===============================
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# ===============================
+# JPA / HIBERNATE (COMUM)
+# ===============================
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# ===============================
+# FLYWAY
+# ===============================
+spring.flyway.enabled=false


### PR DESCRIPTION
- Criado application-test.properties para configuração de teste
- Criada FabricaObjetosTeste para centralizar mocks de entidades e DTOs
- Implementados testes unitários positivos e negativos da PrevisaoService